### PR TITLE
W-11091826 Manage Expenditures Component

### DIFF
--- a/force-app/main/default/lwc/manageExpenditures/manageExpenditures.js
+++ b/force-app/main/default/lwc/manageExpenditures/manageExpenditures.js
@@ -36,7 +36,7 @@ const REFRESH_LABEL = "Refresh List";
 const SAVE_UPDATES_LABEL = "Save Updates";
 const LOADING_ALTERNATIVE_TEXT = "Loading";
 
-export default class ManageExpenditures extends LightningElement(LightningElement) {
+export default class ManageExpenditures extends LightningElement {
     labels = {
         isNotDisbursement: {
             warningBanner: {

--- a/robot/OutboundFundsNPSP/doc/Keywords.html
+++ b/robot/OutboundFundsNPSP/doc/Keywords.html
@@ -285,6 +285,18 @@
                                 </td>
                             </tr>
 
+                            <tr class="kwrow" id="OutboundFundsNPSP.py.Select Tab">
+                                <td class="kwname">
+                                    Select Tab
+                                </td>
+                                <td class="kwargs">
+
+                                    <i>title</i>
+
+                                </td>
+                                <td class="kwdoc"><p>Switch between different tabs on a record page like Related, Details, News, Activity and Chatter Pass title of the tab</p></td>
+                            </tr>
+
                             <tr
                                 class="kwrow"
                                 id="OutboundFundsNPSP.py.Generate New String"

--- a/robot/OutboundFundsNPSP/doc/Keywords.html
+++ b/robot/OutboundFundsNPSP/doc/Keywords.html
@@ -286,15 +286,17 @@
                             </tr>
 
                             <tr class="kwrow" id="OutboundFundsNPSP.py.Select Tab">
-                                <td class="kwname">
-                                    Select Tab
-                                </td>
+                                <td class="kwname">Select Tab</td>
                                 <td class="kwargs">
-
                                     <i>title</i>
-
                                 </td>
-                                <td class="kwdoc"><p>Switch between different tabs on a record page like Related, Details, News, Activity and Chatter Pass title of the tab</p></td>
+                                <td class="kwdoc">
+                                    <p>
+                                        Switch between different tabs on a record page
+                                        like Related, Details, News, Activity and Chatter
+                                        Pass title of the tab
+                                    </p>
+                                </td>
                             </tr>
 
                             <tr

--- a/robot/OutboundFundsNPSP/resources/OutboundFundsNPSP.py
+++ b/robot/OutboundFundsNPSP/resources/OutboundFundsNPSP.py
@@ -2,16 +2,17 @@ import logging
 import random
 import string
 import warnings
+import time
 
 from BaseObjects import BaseOutboundFundsNPSPPage
 from robot.libraries.BuiltIn import RobotNotRunningError
-from locators_52 import outboundfundsnpsp_lex_locators as locators_52
+from locators_54 import outboundfundsnpsp_lex_locators as locators_54
 from locators_51 import outboundfundsnpsp_lex_locators as locators_51
 from cumulusci.robotframework.utils import selenium_retry, capture_screenshot_on_error
 
 locators_by_api_version = {
     51.0: locators_51,  # Spring '21
-    52.0: locators_52,  # Summer '21
+    54.0: locators_54,  
 }
 # will get populated in _init_locators
 outboundfundsnpsp_lex_locators = {}
@@ -239,6 +240,30 @@ class OutboundFundsNPSP(BaseOutboundFundsNPSPPage):
         assert int(value) == count, "Expected value to be {} but found {}".format(
             value, count
         )
+
+    @capture_screenshot_on_error
+    def select_tab(self, title):
+        """ Switch between different tabs on a record page like Related, Details, News, Activity and Chatter
+            Pass title of the tab
+        """
+        tab_found = False
+        locators = outboundfundsnpsp_lex_locators["tabs"].values()
+        for i in locators:
+            locator = i.format(title)
+            if self.check_if_element_exists(locator):
+                print(locator)
+                buttons = self.selenium.get_webelements(locator)
+                for button in buttons:
+                    print(button)
+                    if button.is_displayed():
+                        print("button displayed is {}".format(button))
+                        self.salesforce._focus(button)
+                        button.click()
+                        time.sleep(5)
+                        tab_found = True
+                        break
+
+        assert tab_found, "tab not found"
 
     @capture_screenshot_on_error
     def select_value_from_picklist(self, dropdown, value):

--- a/robot/OutboundFundsNPSP/resources/OutboundFundsNPSP.py
+++ b/robot/OutboundFundsNPSP/resources/OutboundFundsNPSP.py
@@ -12,7 +12,7 @@ from cumulusci.robotframework.utils import selenium_retry, capture_screenshot_on
 
 locators_by_api_version = {
     51.0: locators_51,  # Spring '21
-    54.0: locators_54,  
+    54.0: locators_54,
 }
 # will get populated in _init_locators
 outboundfundsnpsp_lex_locators = {}

--- a/robot/OutboundFundsNPSP/resources/locators_51.py
+++ b/robot/OutboundFundsNPSP/resources/locators_51.py
@@ -1,6 +1,6 @@
 """ Locators for Spring '21 """
 
-from locators_52 import outboundfundsnpsp_lex_locators
+from locators_54 import outboundfundsnpsp_lex_locators
 import copy
 
 outboundfundsnpsp_lex_locators = copy.deepcopy(outboundfundsnpsp_lex_locators)

--- a/robot/OutboundFundsNPSP/resources/locators_54.py
+++ b/robot/OutboundFundsNPSP/resources/locators_54.py
@@ -1,4 +1,4 @@
-# Summer '21 locators
+# Spring '22 locators
 outboundfundsnpsp_lex_locators = {
     "app_launcher": {
         "view_all_button": "//button[text()='View All']",
@@ -13,7 +13,7 @@ outboundfundsnpsp_lex_locators = {
         "edit_title": "//h2[contains(@class, 'title') and text()='{}']",
         "list": "//div[contains(@class,'forcePageBlockSectionRow')]/div[contains(@class,'forcePageBlockItem')]/div[contains(@class,'slds-hint-parent')]/div[@class='slds-form-element__control']/div[.//span[text()='{}']][//div[contains(@class,'uiMenu')]//a[@class='select']]",
         "text_field": "//div[contains(@class, 'uiInput')][.//label[contains(@class, 'uiLabel')][.//span[text()='{}']]]//*[self::input or self::textarea]",
-        "dropdown_field": "//lightning-combobox[./label[text()='{}']]/div//input[contains(@class,'combobox__input')]",
+        "dropdown_field": "//lightning-combobox[./label[text()='{}']]/div//button[contains(@class,'slds-combobox__input')]",
         "dropdown_popup": "//div[contains(@class, 'slds-dropdown-trigger')]/div[contains(@class, 'slds-listbox')]",
         "dropdown_value": "//div[contains(@class,'slds-listbox')]//lightning-base-combobox-item//span[text()='{}']",
         "dd_selection": "//lightning-base-combobox-item[@data-value='{}']",
@@ -39,6 +39,10 @@ outboundfundsnpsp_lex_locators = {
         "verify_header": "//div[contains(@class, 'entityNameTitle')]",
         "verify_details": "//div[contains(@class, 'slds-form-element')][.//span[text()='{}']]//following-sibling::div[.//span[contains(@class, 'test-id__field-value')]]/span",
     },
+    "tabs":{
+    		"tab": "//div[@class='uiTabBar']/ul[@class='tabs__nav']/li[contains(@class,'uiTabItem')]/a[@class='tabHeader']/span[contains(text(), '{}')]",
+    		"spl-tab":"//div[@class='slds-tabs_default']//ul[@class='slds-tabs_default__nav']/li[contains(@class,'slds-tabs_default__item')]/a[text()= '{}']",
+    	},
     "related": {
         "title": '//div[contains(@class, "slds-card")]/header[.//span[@title="{}"]]',
         "button": "//div[contains(@class, 'forceRelatedListSingleContainer')][.//img][.//span[@title='{}']]//a[@title='{}']",

--- a/robot/OutboundFundsNPSP/resources/locators_54.py
+++ b/robot/OutboundFundsNPSP/resources/locators_54.py
@@ -39,10 +39,10 @@ outboundfundsnpsp_lex_locators = {
         "verify_header": "//div[contains(@class, 'entityNameTitle')]",
         "verify_details": "//div[contains(@class, 'slds-form-element')][.//span[text()='{}']]//following-sibling::div[.//span[contains(@class, 'test-id__field-value')]]/span",
     },
-    "tabs":{
-    		"tab": "//div[@class='uiTabBar']/ul[@class='tabs__nav']/li[contains(@class,'uiTabItem')]/a[@class='tabHeader']/span[contains(text(), '{}')]",
-    		"spl-tab":"//div[@class='slds-tabs_default']//ul[@class='slds-tabs_default__nav']/li[contains(@class,'slds-tabs_default__item')]/a[text()= '{}']",
-    	},
+    "tabs": {
+        "tab": "//div[@class='uiTabBar']/ul[@class='tabs__nav']/li[contains(@class,'uiTabItem')]/a[@class='tabHeader']/span[contains(text(), '{}')]",
+        "spl-tab": "//div[@class='slds-tabs_default']//ul[@class='slds-tabs_default__nav']/li[contains(@class,'slds-tabs_default__item')]/a[text()= '{}']",
+    },
     "related": {
         "title": '//div[contains(@class, "slds-card")]/header[.//span[@title="{}"]]',
         "button": "//div[contains(@class, 'forceRelatedListSingleContainer')][.//img][.//span[@title='{}']]//a[@title='{}']",

--- a/robot/OutboundFundsNPSP/tests/browser/Requirements/Requirements.robot
+++ b/robot/OutboundFundsNPSP/tests/browser/Requirements/Requirements.robot
@@ -45,5 +45,6 @@ Add a Requirement on a Funding Request
     Click Save
     wait until modal is closed
     Click Related List Link With Text           ${req_name}
+    Select Tab                                  Details
     Validate Field Value                        Requirement Name    contains    ${req_name}
     Validate Field Value                        Primary Contact    contains    ${contact}[Name]

--- a/robot/OutboundFundsNPSP/tests/create_contact.robot
+++ b/robot/OutboundFundsNPSP/tests/create_contact.robot
@@ -41,5 +41,5 @@ Validate Contact
     Page Should Contain  ${first_name} ${last_name}
     # Validate via API
     &{contact} =     Salesforce Get  Contact  ${contact_id}
-    Should Be Equal  ${first_name}  &{contact}[FirstName]
-    Should Be Equal  ${last_name}  &{contact}[LastName]
+    Should Be Equal  ${first_name}  ${contact['FirstName']}
+    Should Be Equal  ${last_name}  ${contact['LastName']}


### PR DESCRIPTION
GUS: [W-11091826: Outbound Funds/NPSP Extension - Manage Expenditures component](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00000wG44tYAC/view)

# Critical Changes

# Changes
Enabling Lightning Web Security surfaced an issue with the Manage Expenditure Component where Disbursement record page does not load. This PR fixes the issue.

# Issues Closed

# New Metadata

# Deleted Metadata

# Definition of Done

Refer to [Definition of Done](https://salesforce.quip.com/9P7hAOPHJJyU) to see any additional details for the items below:

- [x] Any net new LWC work has JEST test coverage 50% or above
- [x] Default Sa11y tests pass for all LWC components
- [x] 🔒 Secure both Front-end (LWC) & back-end (Apex) as necessary
- [x] 🔑 Grant users access in Permission Sets (Object, Field, Apex Class) as necessary
- [x] Link the pull request and work item by PR comment and Chatter post respectively, e.g. GUS: [W-0000000: Work Name]()
- [x] Make sure that ACs are updated (if any gaps)
- [ ] **All acceptance criteria have been met**
  - [x] Developer
  - [ ] Code Reviewer
- [x] Pull Request contains draft release notes
- [x] Labels, help text, and customer facing messages are reviewed by Docs
- [ ] QE story level testing completed
